### PR TITLE
Make teamName field nullable

### DIFF
--- a/sql/main.sql
+++ b/sql/main.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS `accounts` (
   `accountId` bigint(20) NOT NULL AUTO_INCREMENT,
   `name` varchar(32) NOT NULL,
   `password` varchar(32) NOT NULL,
-  `teamName` varchar(64) NOT NULL,
+  `teamName` varchar(64) NULL,
   `authority` int(11) NOT NULL DEFAULT '0',
   `settings` varchar(512) NOT NULL DEFAULT '',
   PRIMARY KEY (`accountId`)
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS `characters` (
   `characterId` bigint(20) NOT NULL AUTO_INCREMENT,
   `accountId` bigint(20) NOT NULL,
   `name` varchar(64) NOT NULL,
-  `teamName` varchar(32) NOT NULL,
+  `teamName` varchar(32) NULL,
   `job` smallint(6) NOT NULL,
   `gender` tinyint(4) NOT NULL,
   `hair` tinyint(4) NOT NULL,

--- a/sql/update_2016-04-02_1.sql
+++ b/sql/update_2016-04-02_1.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `accounts` MODIFY COLUMN `teamName` varchar(64) NULL;
+ALTER TABLE `characters` MODIFY COLUMN `teamName` varchar(32) NULL;


### PR DESCRIPTION
Environment:
* osx 10.11.4
* mysql 5.7.11
* mono 4.2.3

If teamName is not nullable, the LoginServer failed to create accounts and characters.

-  LoginServer failed to create Account
```
[Error] - Failed to create account 'study'.
[Exception] - MySql.Data.MySqlClient.MySqlException: Field 'teamName' doesn't have a default value
  at MySql.Data.MySqlClient.MySqlStream.ReadPacket () <0x314c500 + 0x0019b> in <filename unknown>:0 
  at MySql.Data.MySqlClient.NativeDriver.GetResult (System.Int32& affectedRow, System.Int64& insertedId) <0x31582e8 + 0x0001b> in <filename unknown>:0 
```

-  LoginServer failed to create Character
```
[Error] - Error while handling packet '0007', CB_COMMANDER_CREATE.
[Exception] - MySql.Data.MySqlClient.MySqlException: Field 'teamName' doesn't have a default value
  at MySql.Data.MySqlClient.MySqlStream.ReadPacket () <0x30fe500 + 0x0019b> in <filename unknown>:0 
  at MySql.Data.MySqlClient.NativeDriver.GetResult (System.Int32& affectedRow, System.Int64& insertedId) <0x310a2e8 + 0x0001b> in <filename unknown>:0 
```
