### PR TITLE
/g is reserved for guild chat, so I renamed /go to /tele

### DIFF
--- a/src/ChannelServer/Util/GmCommands.cs
+++ b/src/ChannelServer/Util/GmCommands.cs
@@ -49,7 +49,7 @@ namespace Melia.Channel.Util
 			Add("speed", "<speed>", HandleSpeed);
 			Add("iteminfo", "<name>", HandleItemInfo);
 			Add("monsterinfo", "<name>", HandleMonsterInfo);
-			Add("go", "<destination>", HandleGo);
+			Add("tele", "<destination>", HandleTele);
 			Add("clearinv", "", HandleClearInventory);
 
 			// Dev
@@ -475,11 +475,11 @@ namespace Melia.Channel.Util
 			return CommandResult.Okay;
 		}
 
-		private CommandResult HandleGo(ChannelConnection conn, Character sender, Character target, string command, string[] args)
+		private CommandResult HandleTele(ChannelConnection conn, Character sender, Character target, string command, string[] args)
 		{
 			if (args.Length < 2)
 			{
-				this.SystemMessage(sender, "Destinations: klaipeda, orsha");
+				this.SystemMessage(sender, "Destinations: klaipeda, orsha, fedimian, pvp arena");
 				return CommandResult.InvalidArgument;
 			}
 
@@ -487,6 +487,10 @@ namespace Melia.Channel.Util
 				target.Warp("c_Klaipe", -75, 148, -24);
 			else if (args[1].StartsWith("ors"))
 				target.Warp("c_orsha", 271, 176, 292);
+			else if (args[1].StartsWith("fed"))
+				target.Warp("c_fedimian", -256, 160, -289);
+			else if (args[1].StartsWith("pvp"))
+				target.Warp("pvp_tournament", 18, -31, -49);
 			else
 				this.SystemMessage(sender, "Unknown destination.");
 

--- a/system/conf/commands.conf
+++ b/system/conf/commands.conf
@@ -42,6 +42,9 @@ warp : 50,50
 // Warps to a specific position in the current region
 jump : 50,50
 
+// Warps to a specific city like Klaipeda, Orsha, Fedimian or PvP Arena
+tele : 50,50
+
 // Spawns item
 item : 50,50
 


### PR DESCRIPTION
Before you were forced to write //go YourName <destination> because this GM command conflicted with the guild chat command, now it's more comfortable...