### PR TITLE
Allow multiline hex string for packet.PutBinFromHex

### DIFF
--- a/src/Shared/Network/Packet.cs
+++ b/src/Shared/Network/Packet.cs
@@ -459,7 +459,7 @@ namespace Melia.Shared.Network
 			if (hex == null)
 				throw new ArgumentNullException("hex");
 
-			hex = hex.Trim().Replace(" ", "").Replace("-", "");
+			hex = hex.Trim().Replace(" ", "").Replace("-", "").Replace("\r", "").Replace("\n", "");
 
 			if (hex == "")
 				return;


### PR DESCRIPTION
for example:
```
packet.PutBinFromHex(@"21 1A 00 00 80 3F 2B 1A 00 00 96 43 2E 1A 00 00
00 00 28 1A 00 00 F0 41 CA 1A 00 00 80 3F 34 1A
00 00 B8 41 27 1A 00 00 C8 42 31 1A 00 00 20 42
CD 1A 00 00 00 00 CB 1A 00 00 00 00 CC 1A 00 00
80 3F 88 1A 00 00 A0 40 8D 1A 00 00 80 3F 94 1A
00 00 00 00 53 1A 00 00 00 00 7E 1A 00 00 00 00
C5 22 00 00 00 00 B8 1A 00 00 00 00 C0 1A 00 00
80 3F 8C 1A 00 00 00 00 BF 1A 00 00 00 00 50 1A
00 00 C8 42
");
```