### PR TITLE
Additional barrack packets

### DIFF
--- a/doc/bt/BC_COMMANDER_DESTROY.bt
+++ b/doc/bt/BC_COMMANDER_DESTROY.bt
@@ -2,12 +2,12 @@
 //--- 010 Editor v6.0.2 Binary Template
 //
 // File: BC_COMMANDER_DESTROY.bt
-// Author: exec
-// Revision:
+// Author: exec, celophi
+// Revision: i170175
 // Purpose:
 //--------------------------------------
 
 short op;
 int sequence;
 
-byte index;
+__int64 characterId;

--- a/doc/bt/BC_NORMAL_SetPosition.bt
+++ b/doc/bt/BC_NORMAL_SetPosition.bt
@@ -1,0 +1,23 @@
+//------------------------------------------------
+//--- 010 Editor v8.0 Binary Template
+//
+//      File: BC_NORMAL_SetPosition.bt
+//   Authors: celophi
+//   Version: i170175
+//   Purpose: Notifies the client that the server successfully set the barrack position for an actor.
+//  Category: 
+// File Mask: 
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#include "common.bt"
+
+short op;
+int reserved;
+short packetLength;
+int subOp;
+
+__int64 accountId;
+byte barrackIndex;
+position pos;

--- a/doc/bt/BC_NORMAL_TeamUI.bt
+++ b/doc/bt/BC_NORMAL_TeamUI.bt
@@ -1,0 +1,24 @@
+//------------------------------------------------
+//--- 010 Editor v8.0 Binary Template
+//
+//      File: BC_NORMAL_TeamUI.bt
+//   Authors: celophi
+//   Version: i170175
+//   Purpose: Updates the client UI with character slots, team experience, names, etc.
+//  Category: 
+// File Mask: 
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#include "common.bt"
+
+short op;
+int reserved;
+short packetLength;
+int subOp;
+
+__int64 accountId;
+short purchasedBarrackSlots;
+int teamExp;
+short characterCount;

--- a/doc/bt/CB_SELECT_BARRACK_LAYER.bt
+++ b/doc/bt/CB_SELECT_BARRACK_LAYER.bt
@@ -1,0 +1,17 @@
+//------------------------------------------------
+//--- 010 Editor v8.0 Binary Template
+//
+//      File: CB_SELECT_BARRACK_LAYER.bt
+//   Authors: celophi
+//   Version: i170175
+//   Purpose: Requests the server to send a list of characters for the barrack layer indicated.
+//  Category: 
+// File Mask: 
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+short op;
+int sequence;
+
+int layer;

--- a/sql/update-2017-09-01_1.sql
+++ b/sql/update-2017-09-01_1.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `characters` ADD COLUMN `barrackLayer` INT NOT NULL DEFAULT 1;

--- a/src/LoginServer/Database/Account.cs
+++ b/src/LoginServer/Database/Account.cs
@@ -57,6 +57,11 @@ namespace Melia.Login.Database
 		public int SelectedBarrack { get; set; }
 
 		/// <summary>
+		/// The layer that is currently selected as being viewed.
+		/// </summary>
+		public int SelectedBarracklayer { get; set; }
+
+		/// <summary>
 		/// Creates new account.
 		/// </summary>
 		public Account()
@@ -183,6 +188,15 @@ namespace Melia.Login.Database
 		{
 			LoginServer.Instance.Database.CreateCharacter(this.Id, character);
 			this.AddCharacter(character);
+		}
+
+		/// <summary>
+		/// Sets the selected barrack layer.
+		/// </summary>
+		/// <param name="layer"></param>
+		public void SetSelectedBarrackLayer(int layer)
+		{
+			this.SelectedBarracklayer = layer;
 		}
 
 		/// <summary>

--- a/src/LoginServer/Database/LoginDb.cs
+++ b/src/LoginServer/Database/LoginDb.cs
@@ -159,6 +159,8 @@ namespace Melia.Login.Database
 				cmd.Set("spr", character.Spr);
 				cmd.Set("dex", character.Dex);
 
+				cmd.Set("barrackLayer", character.BarrackLayer);
+
 				cmd.Execute();
 				character.Id = cmd.LastId;
 			}
@@ -196,6 +198,7 @@ namespace Melia.Login.Database
 				cmd.Set("bx", character.BarrackPosition.X);
 				cmd.Set("by", character.BarrackPosition.Y);
 				cmd.Set("bz", character.BarrackPosition.Z);
+				cmd.Set("barrackLayer", character.BarrackLayer);
 
 				cmd.Execute();
 			}
@@ -229,6 +232,7 @@ namespace Melia.Login.Database
 							character.Hair = reader.GetByte("hair");
 							character.Level = reader.GetInt32("level");
 							character.MapId = reader.GetInt32("zone");
+							character.BarrackLayer = reader.GetInt32("barrackLayer");
 
 							var bx = reader.GetFloat("bx");
 							var by = reader.GetFloat("by");

--- a/src/LoginServer/Network/LoginPacketHandler.cs
+++ b/src/LoginServer/Network/LoginPacketHandler.cs
@@ -132,6 +132,7 @@ namespace Melia.Login.Network
 			Send.BC_SERVER_ENTRY(conn, "127.0.0.1", 9001, "127.0.0.1", 9002);
 			Send.BC_COMMANDER_LIST(conn);
 			Send.BC_NORMAL_ZoneTraffic(conn);
+			Send.BC_NORMAL_TeamUI(conn);
 		}
 
 		/// <summary>
@@ -297,6 +298,7 @@ namespace Melia.Login.Network
 			}
 
 			Send.BC_COMMANDER_DESTROY(conn, index);
+			Send.BC_NORMAL_TeamUI(conn);
 		}
 
 		/// <summary>

--- a/src/LoginServer/Network/LoginPacketHandler.cs
+++ b/src/LoginServer/Network/LoginPacketHandler.cs
@@ -186,6 +186,8 @@ namespace Melia.Login.Network
 			LoginServer.Instance.Database.UpdateTeamName(conn.Account.Id, name);
 
 			Send.BC_BARRACKNAME_CHANGE(conn, TeamNameChangeResult.Okay);
+			Send.BC_ACCOUNT_PROP(conn, conn.Account);
+			Send.BC_NORMAL_Run(conn, "THEMA_BUY_SUCCESS");
 		}
 
 		/// <summary>

--- a/src/LoginServer/Network/LoginPacketHandler.cs
+++ b/src/LoginServer/Network/LoginPacketHandler.cs
@@ -330,7 +330,10 @@ namespace Melia.Login.Network
 			}
 
 			// Move
-			character.BarrackPosition = new Position(x, y, z);
+			// This needs to be validated such that a commander may not move to an invalid coordinate.
+			var pos = new Position(x, y, z);
+			character.BarrackPosition = pos;
+			Send.BC_NORMAL_SetPosition(conn, index, pos);
 		}
 
 		/// <summary>

--- a/src/LoginServer/Network/LoginPacketHandler.cs
+++ b/src/LoginServer/Network/LoginPacketHandler.cs
@@ -278,13 +278,13 @@ namespace Melia.Login.Network
 		[PacketHandler(Op.CB_COMMANDER_DESTROY)]
 		public void CB_COMMANDER_DESTROY(LoginConnection conn, Packet packet)
 		{
-			var index = packet.GetByte();
+			var id = packet.GetLong();
 
 			// Get character
-			var character = conn.Account.GetCharacterByIndex(index);
+			var character = conn.Account.GetCharacterById(id);
 			if (character == null)
 			{
-				Log.Warning("CB_COMMANDER_DESTROY: User '{0}' tried to delete a character he doesn't have ({1}).", conn.Account.Name, index);
+				Log.Warning("CB_COMMANDER_DESTROY: User '{0}' tried to delete a character he doesn't have ({1}).", conn.Account.Name, id);
 				Send.BC_MESSAGE(conn, MsgType.CannotDeleteCharacter1);
 				return;
 			}
@@ -297,7 +297,7 @@ namespace Melia.Login.Network
 				return;
 			}
 
-			Send.BC_COMMANDER_DESTROY(conn, index);
+			Send.BC_COMMANDER_DESTROY(conn, character.Index);
 			Send.BC_NORMAL_TeamUI(conn);
 		}
 

--- a/src/LoginServer/Network/LoginPacketHandler.cs
+++ b/src/LoginServer/Network/LoginPacketHandler.cs
@@ -436,5 +436,23 @@ namespace Melia.Login.Network
 		{
 			Send.BC_NORMAL_ZoneTraffic(conn);
 		}
+
+		/// <summary>
+		/// Sent when the user clicks the barrack number.
+		/// </summary>
+		/// <param name="conn"></param>
+		/// <param name="packet"></param>
+		[PacketHandler(Op.CB_SELECT_BARRACK_LAYER)]
+		public void CB_SELECT_BARRACK_LAYER(LoginConnection conn, Packet packet)
+		{
+			var layer = packet.GetInt();
+
+			// Only these two layers are valid currently.
+			if (layer < 1 || layer > 2)
+				return;
+
+			conn.Account.SetSelectedBarrackLayer(layer);
+			Send.BC_COMMANDER_LIST(conn, conn.Account.SelectedBarracklayer);
+		}
 	}
 }

--- a/src/LoginServer/Network/LoginPacketSender.cs
+++ b/src/LoginServer/Network/LoginPacketSender.cs
@@ -8,6 +8,7 @@ using Melia.Shared.Const;
 using Melia.Shared.Network;
 using Melia.Shared.Network.Helpers;
 using Melia.Shared.Util;
+using Melia.Shared.World;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -154,6 +155,25 @@ namespace Melia.Login.Network
 		{
 			var packet = new Packet(Op.BC_COMMANDER_DESTROY);
 			packet.PutByte(index);
+
+			conn.Send(packet);
+		}
+
+		/// <summary>
+		/// Moves a character in the barrack.
+		/// </summary>
+		/// <param name="conn"></param>
+		/// <param name="index"></param>
+		/// <param name="position"></param>
+		public static void BC_NORMAL_SetPosition(LoginConnection conn, byte index, Position position)
+		{
+			var packet = new Packet(Op.BC_NORMAL);
+			packet.PutInt(0x02); // subop
+			packet.PutLong(conn.Account.Id);
+			packet.PutByte(index);
+			packet.PutFloat(position.X);
+			packet.PutFloat(position.Y);
+			packet.PutFloat(position.Z);
 
 			conn.Send(packet);
 		}

--- a/src/LoginServer/Network/LoginPacketSender.cs
+++ b/src/LoginServer/Network/LoginPacketSender.cs
@@ -269,13 +269,17 @@ namespace Melia.Login.Network
 			conn.Send(packet);
 		}
 
+		/// <summary>
+		/// Invokes a lua function.
+		/// </summary>
+		/// <param name="conn"></param>
+		/// <param name="str"></param>
 		public static void BC_NORMAL_Run(LoginConnection conn, string str)
 		{
 			// Probably runs a lua function? Example string: THEMA_BUY_SUCCESS
 
 			var packet = new Packet(Op.BC_NORMAL);
-
-			packet.PutInt(0x0E);
+			packet.PutInt(0x0E); // subOp
 			packet.PutLpString(str);
 
 			conn.Send(packet);

--- a/src/LoginServer/Network/LoginPacketSender.cs
+++ b/src/LoginServer/Network/LoginPacketSender.cs
@@ -178,6 +178,31 @@ namespace Melia.Login.Network
 			conn.Send(packet);
 		}
 
+		/// <summary>
+		/// Sends information related to the team to be displayed in the barrack.
+		/// </summary>
+		/// <param name="conn"></param>
+		public static void BC_NORMAL_TeamUI(LoginConnection conn)
+		{
+			var packet = new Packet(Op.BC_NORMAL);
+			packet.PutInt(0x0B); // SubOp
+
+			packet.PutLong(conn.Account.Id);
+
+			// Need to check the number of slots bought.
+			// slots = (mapDefault - 4 + bought)
+			packet.PutShort(0);
+
+			// Team experience. Displayed under "Team Info"
+			packet.PutInt(0);
+
+			// Sum of characters and pets.
+			var characters = conn.Account.GetCharacters();
+			packet.PutShort(characters.Count());
+
+			conn.Send(packet);
+		}
+
 		public static void BC_NORMAL_ZoneTraffic(LoginConnection conn)
 		{
 			var characters = conn.Account.GetCharacters();

--- a/src/LoginServer/Network/LoginPacketSender.cs
+++ b/src/LoginServer/Network/LoginPacketSender.cs
@@ -49,14 +49,20 @@ namespace Melia.Login.Network
 			conn.Send(packet);
 		}
 
-		public static void BC_COMMANDER_LIST(LoginConnection conn)
+		/// <summary>
+		/// Sends a list of characters to the client.
+		/// </summary>
+		/// <param name="conn"></param>
+		/// <param name="layer">This is the number on the left side of the character list in the client.</param>
+		public static void BC_COMMANDER_LIST(LoginConnection conn, int layer = 1)
 		{
-			var characters = conn.Account.GetCharacters();
+			var characters = conn.Account.GetCharacters()
+				.Where(x => x.BarrackLayer == layer);
 
 			var packet = new Packet(Op.BC_COMMANDER_LIST);
 			packet.PutLong(conn.Account.Id);
 			packet.PutByte(0);
-			packet.PutByte((byte)characters.Length);
+			packet.PutByte((byte)characters.Count());
 			packet.PutString(conn.Account.TeamName, 64);
 
 			packet.AddAccountProperties(conn.Account);

--- a/src/LoginServer/World/Character.cs
+++ b/src/LoginServer/World/Character.cs
@@ -30,6 +30,11 @@ namespace Melia.Login.World
 		public Position BarrackPosition { get; set; }
 
 		/// <summary>
+		/// Layer in the barrack that the character should appear in.
+		/// </summary>
+		public int BarrackLayer { get; set; }
+
+		/// <summary>
 		/// Creates new character.
 		/// </summary>
 		public Character()


### PR DESCRIPTION
Summary:
- Fixes the barrack layer selection being stuck after selecting '2'.
- Updates the client UI when a team name change is purchased (changes not persisted in the database yet.)
- Updates the character's position.
- Fixes deletion of characters.