### PR TITLE
Added quick fix for ZC_CHAT crashing the client.

### DIFF
--- a/src/ChannelServer/Network/ChannelPacketSender.cs
+++ b/src/ChannelServer/Network/ChannelPacketSender.cs
@@ -512,7 +512,7 @@ namespace Melia.Channel.Network
 
 			packet.PutFloat(0); // Display time in seconds, min cap 5s
 			packet.PutString(message);
-
+			packet.PutEmptyBin(16); // message starts at 180 bytes.
 			character.Map.Broadcast(packet, character);
 		}
 


### PR DESCRIPTION
This is just to prevent chat messages from crashing the client. We need to look into completing the implementation of `ZC_CHAT` eventually.