### PR TITLE
Added a logging statement when registering a packet handler function.

### DIFF
--- a/src/Shared/Network/PacketHandler.cs
+++ b/src/Shared/Network/PacketHandler.cs
@@ -105,11 +105,18 @@ namespace Melia.Shared.Network
 		{
 			foreach (var method in this.GetType().GetMethods())
 			{
-				foreach (PacketHandlerAttribute attr in method.GetCustomAttributes(typeof(PacketHandlerAttribute), false))
+				try
 				{
-					var func = (PacketHandlerFunc)Delegate.CreateDelegate(typeof(PacketHandlerFunc), this, method);
-					foreach (var op in attr.Ops)
-						this.Register(op, func);
+					foreach (PacketHandlerAttribute attr in method.GetCustomAttributes(typeof(PacketHandlerAttribute), false))
+					{
+						var func = (PacketHandlerFunc)Delegate.CreateDelegate(typeof(PacketHandlerFunc), this, method);
+						foreach (var op in attr.Ops)
+							this.Register(op, func);
+					}
+				} catch (Exception)
+				{
+					Log.Error("An error occurred while attempting to register the '{0}' method. Please make certain it is defined correctly.", method.Name);
+					throw;
 				}
 			}
 		}


### PR DESCRIPTION
I added this change for myself just to catch myself from making silly mistakes, but maybe it is useful here as well.

Basically, I had declared a handler which didn't match the delegate type. The consequence was that an error was thrown, but without a clear indication of what was causing the problem (no stack trace, target message). This will at the very least let the developer know which method name doesn't match the delegate signature so that it can be fixed.