### PR TITLE
Default equipment for character creation.

### DIFF
--- a/src/LoginServer/Database/LoginDb.cs
+++ b/src/LoginServer/Database/LoginDb.cs
@@ -134,39 +134,59 @@ namespace Melia.Login.Database
 		public void CreateCharacter(long accountId, Character character)
 		{
 			using (var conn = this.GetConnection())
-			using (var cmd = new InsertCommand("INSERT INTO `characters` {0}", conn))
+			using (var trans = conn.BeginTransaction())
 			{
-				cmd.Set("accountId", accountId);
-				cmd.Set("name", character.Name);
-				cmd.Set("teamName", character.TeamName);
-				cmd.Set("job", character.Job);
-				cmd.Set("gender", character.Gender);
-				cmd.Set("hair", character.Hair);
+				using (var cmd = new InsertCommand("INSERT INTO `characters` {0}", conn))
+				{
+					cmd.Set("accountId", accountId);
+					cmd.Set("name", character.Name);
+					cmd.Set("teamName", character.TeamName);
+					cmd.Set("job", character.Job);
+					cmd.Set("gender", character.Gender);
+					cmd.Set("hair", character.Hair);
 
-				cmd.Set("zone", character.MapId);
-				cmd.Set("x", character.Position.X);
-				cmd.Set("y", character.Position.Y);
-				cmd.Set("z", character.Position.Z);
-				cmd.Set("bx", character.BarrackPosition.X);
-				cmd.Set("by", character.BarrackPosition.Y);
-				cmd.Set("bz", character.BarrackPosition.Z);
+					cmd.Set("zone", character.MapId);
+					cmd.Set("x", character.Position.X);
+					cmd.Set("y", character.Position.Y);
+					cmd.Set("z", character.Position.Z);
+					cmd.Set("bx", character.BarrackPosition.X);
+					cmd.Set("by", character.BarrackPosition.Y);
+					cmd.Set("bz", character.BarrackPosition.Z);
 
-				cmd.Set("hp", character.Hp);
-				cmd.Set("maxHp", character.MaxHp);
-				cmd.Set("sp", character.Sp);
-				cmd.Set("maxSp", character.MaxSp);
-				cmd.Set("stamina", character.Stamina);
-				cmd.Set("maxStamina", character.MaxStamina);
-				cmd.Set("str", character.Str);
-				cmd.Set("con", character.Con);
-				cmd.Set("int", character.Int);
-				cmd.Set("spr", character.Spr);
-				cmd.Set("dex", character.Dex);
+					cmd.Set("hp", character.Hp);
+					cmd.Set("maxHp", character.MaxHp);
+					cmd.Set("sp", character.Sp);
+					cmd.Set("maxSp", character.MaxSp);
+					cmd.Set("stamina", character.Stamina);
+					cmd.Set("maxStamina", character.MaxStamina);
+					cmd.Set("str", character.Str);
+					cmd.Set("con", character.Con);
+					cmd.Set("int", character.Int);
+					cmd.Set("spr", character.Spr);
+					cmd.Set("dex", character.Dex);
 
-				cmd.Set("barrackLayer", character.BarrackLayer);
+					cmd.Set("barrackLayer", character.BarrackLayer);
 
-				cmd.Execute();
-				character.Id = cmd.LastId;
+					cmd.Execute();
+					character.Id = cmd.LastId;
+				}
+
+				var i = 0;
+				foreach (var item in character.Equipment)
+				{
+					using (var cmd = new InsertCommand("INSERT INTO `items` {0}", conn))
+					{
+						cmd.Set("characterId", character.Id);
+						cmd.Set("itemId", item);
+						cmd.Set("amount", 1);
+						cmd.Set("sort", 0);
+						cmd.Set("equipSlot", i++);
+
+						cmd.Execute();
+					}
+				}
+
+				trans.Commit();
 			}
 		}
 

--- a/src/LoginServer/LoginServer.cs
+++ b/src/LoginServer/LoginServer.cs
@@ -45,7 +45,7 @@ namespace Melia.Login
 			CliUtil.LoadingTitle();
 
 			// Data
-			this.LoadData(DataToLoad.Jobs | DataToLoad.Maps | DataToLoad.Barracks | DataToLoad.Servers, true);
+			this.LoadData(DataToLoad.Jobs | DataToLoad.Maps | DataToLoad.Barracks | DataToLoad.Servers | DataToLoad.Items, true);
 
 			// Conf
 			this.LoadConf(this.Conf = new LoginConf());

--- a/src/LoginServer/Network/LoginPacketHandler.cs
+++ b/src/LoginServer/Network/LoginPacketHandler.cs
@@ -258,6 +258,12 @@ namespace Melia.Login.Network
 			character.Spr = jobData.Spr;
 			character.Dex = jobData.Dex;
 
+			if (!character.SetDefaultEquipment())
+			{
+				Log.Error("CB_COMMANDER_CREATE: An error occurred while setting the default equipment for a new character.");
+				return;
+			}
+
 			conn.Account.CreateCharacter(character);
 
 			Send.BC_COMMANDER_CREATE_SLOTID(conn, character);

--- a/src/LoginServer/World/Character.cs
+++ b/src/LoginServer/World/Character.cs
@@ -6,6 +6,8 @@ using Melia.Login.Network.Helpers;
 using Melia.Shared.Const;
 using Melia.Shared.World;
 using Melia.Shared.Util;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Melia.Login.World
 {
@@ -67,31 +69,13 @@ namespace Melia.Login.World
 		}
 
 		/// <summary>
-		/// Sets the default equipment for a character.
+		/// Sets the equipment for a character.
 		/// </summary>
 		/// <returns></returns>
-		public bool SetDefaultEquipment()
+		public void SetEquipment(IDictionary<EquipSlot, int> equipment)
 		{
-			var jobData = LoginServer.Instance.Data.JobDb.Find(this.Job);
-			if (jobData == null)
-			{
-				Log.Error("SetDefaultEquipment : Unable to set default equipment for job '{0}' because it doesn't exist.", this.Job);
-				return false;
-			}
-
-			foreach (var equip in jobData.DefaultEquip)
-			{
-				var itemData = LoginServer.Instance.Data.ItemDb.FindByClass(equip.Value);
-				if (itemData == null)
-				{
-					Log.Error("SetDefaultEquipment : Unable to find item data with class name '{0}'.", equip.Value);
-					return false;
-				}
-
-				this.Equipment[(int)equip.Key] = itemData.Id;
-			}
-
-			return true;
+			foreach (var item in equipment)
+				this.Equipment[(int)item.Key] = item.Value;
 		}
 	}
 }

--- a/src/LoginServer/World/Character.cs
+++ b/src/LoginServer/World/Character.cs
@@ -81,7 +81,7 @@ namespace Melia.Login.World
 
 			foreach (var equip in jobData.DefaultEquip)
 			{
-				var itemData = LoginServer.Instance.Data.ItemDb.Find(equip.Value);
+				var itemData = LoginServer.Instance.Data.ItemDb.FindByClass(equip.Value);
 				if (itemData == null)
 				{
 					Log.Error("SetDefaultEquipment : Unable to find item data with class name '{0}'.", equip.Value);

--- a/src/LoginServer/World/Character.cs
+++ b/src/LoginServer/World/Character.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Melia.Login.Network.Helpers;
 using Melia.Shared.Const;
 using Melia.Shared.World;
+using Melia.Shared.Util;
 
 namespace Melia.Login.World
 {
@@ -63,6 +64,34 @@ namespace Melia.Login.World
 		{
 			// TODO: This needs to return the actual properties of equipment which have variable lengths.
 			return this.GetEquipIds();
+		}
+
+		/// <summary>
+		/// Sets the default equipment for a character.
+		/// </summary>
+		/// <returns></returns>
+		public bool SetDefaultEquipment()
+		{
+			var jobData = LoginServer.Instance.Data.JobDb.Find(this.Job);
+			if (jobData == null)
+			{
+				Log.Error("SetDefaultEquipment : Unable to set default equipment for job '{0}' because it doesn't exist.", this.Job);
+				return false;
+			}
+
+			foreach (var equip in jobData.DefaultEquip)
+			{
+				var itemData = LoginServer.Instance.Data.ItemDb.Find(equip.Value);
+				if (itemData == null)
+				{
+					Log.Error("SetDefaultEquipment : Unable to find item data with class name '{0}'.", equip.Value);
+					return false;
+				}
+
+				this.Equipment[(int)equip.Key] = itemData.Id;
+			}
+
+			return true;
 		}
 	}
 }

--- a/src/Shared/Const/Items.cs
+++ b/src/Shared/Const/Items.cs
@@ -52,28 +52,28 @@ namespace Melia.Shared.Const
 	/// </remarks>
 	public enum EquipSlot : byte
 	{
-		HairAccessory,
-		SubsidiaryAccessory,
-		Hair, // [i11025 (2016-02-26)]
-		_Outer1,
-		Top,
-		Costume,
-		Shoes,
-		_Helmet,
-		Armband,
-		LeftHand,
-		RightHand,
-		Gloves,
-		_Ring1,
-		_Ring2,
-		_Outer2,
-		Pants,
-		_Ring3,
-		_Ring4,
-		Bracelet1,
-		Bracelet2,
-		Necklace,
-		Lens,
+		HairAccessory, // HAT
+		SubsidiaryAccessory, // HAT_L
+		Hair, // HAIR
+		Top, // SHIRT
+		Gloves, // GLOVES
+		Shoes, // BOOTS
+		Helmet, // HELMET
+		Armband, // ARMBAND
+		RightHand, // RH
+		LeftHand, // LH
+		Outer1, // OUTER
+		Ring1, // OUTERADD1
+		Ring2, // OUTERADD2
+		Outer2, // BODY
+		Pants, // PANTS
+		Ring3, // PANTSADD1
+		Ring4, // PANTSADD2
+		Bracelet1, // RING1
+		Bracelet2, // RING2
+		Necklace, // NECK
+		Hat, // HAT_T
+		Lens, // LENS
 	}
 
 	public enum InventoryItemRemoveMsg : byte

--- a/src/Shared/Const/Items.cs
+++ b/src/Shared/Const/Items.cs
@@ -74,6 +74,7 @@ namespace Melia.Shared.Const
 		Necklace, // NECK
 		Hat, // HAT_T
 		Lens, // LENS
+		Wing, // WING
 	}
 
 	public enum InventoryItemRemoveMsg : byte

--- a/src/Shared/Data/Database/Items.cs
+++ b/src/Shared/Data/Database/Items.cs
@@ -33,6 +33,12 @@ namespace Melia.Shared.Data.Database
 			return this.Entries.FirstOrDefault(a => a.Value.Name.ToLower() == name).Value;
 		}
 
+		public ItemData FindByClass(string name)
+		{
+			name = name.ToLower();
+			return this.Entries.FirstOrDefault(a => a.Value.ClassName.ToLower() == name).Value;
+		}
+
 		public List<ItemData> FindAll(string name)
 		{
 			name = name.ToLower();


### PR DESCRIPTION
This change adds the default equipment necessary when we create characters.

Note:
- There is one inventory item which seems to be incorrect in our default items array. We'll need to change this to the correct id.